### PR TITLE
Added statistics model, updated revenue model

### DIFF
--- a/models/core/dm_monthly_zone_revenue.sql
+++ b/models/core/dm_monthly_zone_revenue.sql
@@ -23,9 +23,9 @@ with trips_data as (
     sum(congestion_surcharge) as revenue_monthly_congestion_surcharge,
 
     -- Additional calculations
-    count(tripid) as total_monthly_trips,
-    avg(passenger_count) as avg_montly_passenger_count,
-    avg(trip_distance) as avg_montly_trip_distance
+    --count(tripid) as total_monthly_trips,
+   -- avg(passenger_count) as avg_montly_passenger_count,
+   -- avg(trip_distance) as avg_montly_trip_distance
 
     from trips_data
     group by 1,2,3

--- a/models/core/dm_monthly_zone_statistics.sql
+++ b/models/core/dm_monthly_zone_statistics.sql
@@ -1,0 +1,20 @@
+{{ config(materialized='table') }}
+
+with trips_data as (
+select * from {{ ref('fact_trips') }}
+)
+select
+-- Reveneue grouping
+pickup_zone as revenue_zone,
+date_trunc('month', pickup_datetime) as revenue_month,
+--Note: For BQ use instead: date_trunc(pickup_datetime, month) as revenue_month,
+
+service_type,
+
+-- Additional calculations
+count(tripid) as total_monthly_trips,
+avg(passenger_count) as avg_montly_passenger_count,
+avg(trip_distance) as avg_montly_trip_distance
+
+from trips_data
+group by 1,2,3


### PR DESCRIPTION

# Impact Summary
### Code Changes
| Added | Removed | Modified
| -- | -- | --
| 1 | 0 | 1
### Resource Impact
| Potentially Impacted | Assessed | Impacted
| -- | -- | --
| 2 | 2 assessed, 0 skipped | 1
# Resource Impact
### Models
| &nbsp;&nbsp;&nbsp; | Model | Impact | Columns <br> <img src="https://raw.githubusercontent.com/InfuseAI/piperider/main/images/icons/icon-diff-delta-plus%402x.png" width="10px"> <img src="https://raw.githubusercontent.com/InfuseAI/piperider/main/images/icons/icon-diff-delta-minus%402x.png" width="10px"> <img src="https://raw.githubusercontent.com/InfuseAI/piperider/main/images/icons/icon-diff-delta-explicit%402x.png" width="10px"> | Rows | Dbt Time | Failed Tests | All Tests
| -- | -- | -- | -- | -- | -- | -- | --
| <img src="https://raw.githubusercontent.com/InfuseAI/piperider/main/images/icons/icon-diff-delta-explicit%402x.png" width="16px"> | ..\dm_monthly_zone_revenue.sql | Impacted | 12 ($\color{green}{\text{ 0 }}$ / $\color{red}{\text{ 3 }}$ / $\color{orange}{\text{ 0 }}$) | 5599 | 0:00:00.08 $\color{red}{\text{ (↑ 0.00) }}$ | 0 | 1
| <img src="https://raw.githubusercontent.com/InfuseAI/piperider/main/images/icons/icon-diff-delta-plus%402x.png" width="16px"> | .._monthly_zone_statistics.sql | Assessed not impacted | 6 | 5599 | 0:00:00.06 | - | -
### Metrics
No changes detected
